### PR TITLE
Build vocab separately for text and query fields

### DIFF
--- a/lib/datasets/torchtext/common.py
+++ b/lib/datasets/torchtext/common.py
@@ -36,7 +36,7 @@ class TorchtextDataset(Dataset):
 
         vectors = Vectors(name=WORD2VEC_EMBEDDING_FILE, cache=WORD2VEC_EMBEDDING_DIR, unk_init=torch.Tensor.zero_)
         self.input_field.build_vocab(train_dataset, dev_dataset, test_dataset, vectors=vectors)
-        self.query_field.vocab = self.input_field.vocab
+        self.query_field.build_vocab(train_dataset, dev_dataset, test_dataset, vectors=vectors)
 
         return BucketIterator.splits((train_dataset, dev_dataset, test_dataset), batch_size=batch_size,
                                      repeat=False, shuffle=True, sort_within_batch=True, device=device)

--- a/lib/models/sm_cnn/__main__.py
+++ b/lib/models/sm_cnn/__main__.py
@@ -53,7 +53,8 @@ if __name__ == '__main__':
     config = deepcopy(args)
     config.dataset = train_iter.dataset
     config.target_class = dataset.NUM_CLASSES
-    config.words_num = len(train_iter.dataset.fields['input'].vocab)
+    config.input_vocab_len = len(train_iter.dataset.fields['input'].vocab)
+    config.query_vocab_len = len(train_iter.dataset.fields['query'].vocab)
 
     print('Dataset:', args.dataset)
     print('No. of train examples:', len(train_iter.dataset))

--- a/lib/models/sm_cnn/args.py
+++ b/lib/models/sm_cnn/args.py
@@ -7,9 +7,8 @@ def get_args():
     parser = models.args.get_args()
 
     parser.add_argument('--dataset', type=str, required=True, choices=['microblog', 'msmarco'])
-    parser.add_argument('--mode', type=str, default='static', choices=['rand', 'static', 'non-static', 'multichannel'])
+    parser.add_argument('--mode', type=str, default='static', choices=['rand', 'static', 'non-static'])
     parser.add_argument('--output-channel', type=int, default=100)
-    parser.add_argument('--words-dim', type=int, default=300)
     parser.add_argument('--embed-dim', type=int, default=300)
     parser.add_argument('--dropout', type=float, default=0.5)
     parser.add_argument('--epoch-decay', type=int, default=15)

--- a/lib/models/sm_cnn/encoder.py
+++ b/lib/models/sm_cnn/encoder.py
@@ -8,56 +8,19 @@ class KimCNNEncoder(nn.Module):
     def __init__(self, args):
         super().__init__()
         self.args = args
+        input_channel = 1
 
-        dataset = args.dataset
-        words_num = args.words_num
-        words_dim = args.words_dim
-        target_class = args.target_class
-        output_channel = args.output_channel
-
-        if args.mode == 'rand':
-            input_channel = 1
-            rand_embed_init = torch.Tensor(words_num, words_dim).uniform_(-0.25, 0.25)
-            self.embed = nn.Embedding.from_pretrained(rand_embed_init, freeze=False)
-        elif args.mode == 'static':
-            input_channel = 1
-            self.static_embed = nn.Embedding.from_pretrained(dataset.fields['input'].vocab.vectors, freeze=True)
-        elif args.mode == 'non-static':
-            input_channel = 1
-            self.non_static_embed = nn.Embedding.from_pretrained(dataset.fields['input'].vocab.vectors, freeze=False)
-        elif args.mode == 'multichannel':
-            input_channel = 2
-            self.static_embed = nn.Embedding.from_pretrained(dataset.fields['input'].vocab.vectors, freeze=True)
-            self.non_static_embed = nn.Embedding.from_pretrained(dataset.fields['input'].vocab.vectors, freeze=False)
-        else:
-            raise ValueError("Unsupported embedding mode")
-
-        self.conv1 = nn.Conv2d(input_channel, output_channel, (3, words_dim), padding=(2,0))
-        self.conv2 = nn.Conv2d(input_channel, output_channel, (4, words_dim), padding=(3,0))
-        self.conv3 = nn.Conv2d(input_channel, output_channel, (5, words_dim), padding=(4,0))
-
+        self.conv1 = nn.Conv2d(input_channel, args.output_channel, (3, args.embed_dim), padding=(2, 0))
+        self.conv2 = nn.Conv2d(input_channel, args.output_channel, (4, args.embed_dim), padding=(3, 0))
+        self.conv3 = nn.Conv2d(input_channel, args.output_channel, (5, args.embed_dim), padding=(4, 0))
         self.dropout = nn.Dropout(args.dropout)
-        self.fc1 = nn.Linear(3 * output_channel, target_class)
 
     def forward(self, x):
-        if self.args.mode == 'rand':
-            word_input = self.embed(x)  # (batch, sent_len, embed_dim)
-            x = word_input.unsqueeze(1)  # (batch, channel_input, sent_len, embed_dim)
-        elif self.args.mode == 'static':
-            static_input = self.static_embed(x)
-            x = static_input.unsqueeze(1)  # (batch, channel_input, sent_len, embed_dim)
-        elif self.args.mode == 'non-static':
-            non_static_input = self.non_static_embed(x)
-            x = non_static_input.unsqueeze(1)  # (batch, channel_input, sent_len, embed_dim)
-        elif self.args.mode == 'multichannel':
-            non_static_input = self.non_static_embed(x)
-            static_input = self.static_embed(x)
-            x = torch.stack([non_static_input, static_input], dim=1)  # (batch, channel_input=2, sent_len, embed_dim)
-
         x = [F.relu(self.conv1(x)).squeeze(3),
              F.relu(self.conv2(x)).squeeze(3),
              F.relu(self.conv3(x)).squeeze(3)]  # (batch, channel_output, ~=sent_len) * num_conv
 
         x = [F.max_pool1d(i, i.size(2)).squeeze(2) for i in x]  # (batch, channel_output) * num_conv
         x = torch.cat(x, 1)  # (batch, channel_output * num_conv)
+        x = self.dropout(x)
         return x

--- a/lib/models/sm_cnn/model.py
+++ b/lib/models/sm_cnn/model.py
@@ -7,13 +7,25 @@ from models.sm_cnn.encoder import KimCNNEncoder
 class SiameseCNN(nn.Module):
     def __init__(self, args):
         super().__init__()
+
+        if args.mode == 'rand':
+            query_embed_init = torch.Tensor(args.query_vocab_len, args.embed_dim).uniform_(-0.25, 0.25)
+            self.query_embed = nn.Embedding.from_pretrained(query_embed_init, freeze=False)
+            input_embed_init = torch.Tensor(args.input_vocab_len, args.embed_dim).uniform_(-0.25, 0.25)
+            self.input_embed = nn.Embedding.from_pretrained(input_embed_init, freeze=False)
+        else:
+            is_frozen = (args.mode == 'static')
+            self.query_embed = nn.Embedding.from_pretrained(args.dataset.fields['query'].vocab.vectors, is_frozen)
+            self.input_embed = nn.Embedding.from_pretrained(args.dataset.fields['input'].vocab.vectors, is_frozen)
+
         self.encoder = KimCNNEncoder(args)
-        self.dropout = nn.Dropout(args.dropout)
         self.fc1 = nn.Linear(6 * args.output_channel, args.target_class)
 
     def forward(self, query, input, **kwargs):
+        query = self.query_embed(query).unsqueeze(1)  # (batch, channel_input, sent_len, embed_dim)
+        input = self.input_embed(input).unsqueeze(1)  # (batch, channel_input, sent_len, embed_dim)
+
         query = self.encoder(query)  # (batch, channel_output * num_conv)
         input = self.encoder(input)  # (batch, channel_output * num_conv)
         x = torch.cat([query, input], 1)   # (batch, 2 * channel_output * num_conv)
-        x = self.dropout(x)
         return self.fc1(x)  # (batch, target_size)


### PR DESCRIPTION
So far, we've shared the same vocab for text and query fields with the assumption that the query vocab is a subset of text vocab. However, under further introspection, this doesn't seem to be the case.